### PR TITLE
Add klayout with gdsfactory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,8 @@
               klayout = callPackage ./nix/klayout.nix {
                 inherit (self) buildPythonEnvForInterpreter;
               };
+              gdsfactory = callPythonPackage ./nix/gdsfactory.nix {};
+              klayout-gdsfactory = callPackage ./nix/klayout-gdsfactory.nix {};
               surelog = callPackage ./nix/surelog.nix {};
               tclFull = callPackage ./nix/tclFull.nix {};
               tk-x11 = callPackage ./nix/tk-x11.nix {};

--- a/nix/build-python-env-for-interpreter.nix
+++ b/nix/build-python-env-for-interpreter.nix
@@ -47,7 +47,7 @@
 }: pkglist: let
   extraLibs = pkglist target.python3.pkgs;
 in
-  # Create an executable of something that embeds Python with additional 
+  # Create an executable of something that embeds Python with additional
   # packages in its specific Python environment.
   let
     env = let
@@ -67,7 +67,7 @@ in
           ''
             rm -rf "$out/bin"
             mkdir -p "$out/bin"
-             
+
             LIBPY_OLD=$out/lib/${python3.libPrefix}
             LIBPY_NEW=$(echo $LIBPY_OLD | sed -e 's@/python@/${target.name}-python@')
             mv $LIBPY_OLD $LIBPY_NEW

--- a/nix/gdsfactory.nix
+++ b/nix/gdsfactory.nix
@@ -17,10 +17,8 @@
   fetchPypi,
   setuptools,
   setuptools_scm,
-
   # Tools
   klayout,
-
   # Python
   matplotlib,
   numpy,
@@ -54,10 +52,8 @@
   cython_0,
   ruamel-yaml,
   jinja2,
-}:
-let
-
-  rectangle-packer = buildPythonPackage rec {
+}: let
+  rectangle-packer = buildPythonPackage {
     pname = "rectangle-packer";
     format = "pyproject";
     version = "2.0.2";
@@ -67,18 +63,17 @@ let
       cython_0
     ];
 
-    propagatedBuildInputs =
-      [
-      ];
+    propagatedBuildInputs = [
+    ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (rectangle-packer) pname version;
       sha256 = "sha256-NORQApJV9ybEqObpOaGMrVh58Nn+WIwYeP6FyHLcvkE=";
     };
     doCheck = false;
   };
 
-  rectpack = buildPythonPackage rec {
+  rectpack = buildPythonPackage {
     pname = "rectpack";
     format = "pyproject";
     version = "0.2.2";
@@ -87,18 +82,17 @@ let
       setuptools
     ];
 
-    propagatedBuildInputs =
-      [
-      ];
+    propagatedBuildInputs = [
+    ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (rectpack) pname version;
       sha256 = "sha256-FeODUF/fuutV7GQKWCXZyizokBmmzdVS1uV+w2xouio=";
     };
     doCheck = false;
   };
 
-  ruamel-yaml-string = buildPythonPackage rec {
+  ruamel-yaml-string = buildPythonPackage {
     pname = "ruamel.yaml.string";
     format = "pyproject";
     version = "0.1.1";
@@ -112,13 +106,13 @@ let
     ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (ruamel-yaml-string) pname version;
       sha256 = "sha256-enrtzAVdRcAE04t1b1hHTr77EGhR9M5WzlhBVwl4Q1A=";
     };
     doCheck = false;
   };
 
-  kfactory = buildPythonPackage rec {
+  kfactory = buildPythonPackage {
     pname = "kfactory";
     format = "pyproject";
     version = "0.18.4";
@@ -146,13 +140,13 @@ let
     ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (kfactory) pname version;
       sha256 = "sha256-2thvsHTlc61U5LiaDLlEAcKYY7Vh2ZGe5Z7tAN1sUtQ=";
     };
     doCheck = false;
   };
 
-  trimesh-4_4_1 = buildPythonPackage rec {
+  trimesh = buildPythonPackage {
     pname = "trimesh";
     format = "pyproject";
     version = "4.4.1";
@@ -166,13 +160,13 @@ let
     ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (trimesh) pname version;
       sha256 = "sha256-dn/jyGa6dObZqdIWw07MHP4vvz8SmmwR1ZhxcFpZGro=";
     };
     doCheck = false;
   };
 
-  self = buildPythonPackage rec {
+  self = buildPythonPackage {
     pname = "gdsfactory";
     format = "pyproject";
     version = "8.7.3";
@@ -204,14 +198,14 @@ let
       mapbox-earcut
       networkx
       #scikit-image
-      trimesh-4_4_1
+      trimesh
       ipykernel
       attrs
       jinja2
     ];
 
     src = fetchPypi {
-      inherit pname version;
+      inherit (self) pname version;
       sha256 = "sha256-F2XMb1bSlg3Psydp1rag7Z4jO9+o23d0EySDY4WhqbI=";
     };
     doCheck = false;
@@ -220,6 +214,14 @@ let
       substituteInPlace pyproject.toml \
         --replace "\"scikit-image\"," ""
     '';
+
+    meta = {
+      description = "python library to design chips (Photonics, Analog, Quantum, MEMs, ...), objects for 3D printing or PCBs.";
+      homepage = "https://gdsfactory.github.io/gdsfactory/";
+      license = [lib.licenses.mit];
+      platforms = lib.platforms.unix;
+      mainProgram = "gf";
+    };
   };
 in
-self
+  self

--- a/nix/gdsfactory.nix
+++ b/nix/gdsfactory.nix
@@ -1,0 +1,225 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  setuptools_scm,
+
+  # Tools
+  klayout,
+
+  # Python
+  matplotlib,
+  numpy,
+  rich,
+  flit-core,
+  orjson,
+  pandas,
+  pydantic,
+  pydantic-settings,
+  pydantic-extra-types,
+  pyyaml,
+  qrcode,
+  scipy,
+  shapely,
+  toolz,
+  types-pyyaml,
+  typer,
+  watchdog,
+  freetype-py,
+  mapbox-earcut,
+  networkx,
+  trimesh,
+  ipykernel,
+  attrs,
+  aenum,
+  cachetools,
+  gitpython,
+  loguru,
+  requests,
+  tomli,
+  cython_0,
+  ruamel-yaml,
+  jinja2,
+}:
+let
+
+  rectangle-packer = buildPythonPackage rec {
+    pname = "rectangle-packer";
+    format = "pyproject";
+    version = "2.0.2";
+
+    buildInputs = [
+      setuptools
+      cython_0
+    ];
+
+    propagatedBuildInputs =
+      [
+      ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-NORQApJV9ybEqObpOaGMrVh58Nn+WIwYeP6FyHLcvkE=";
+    };
+    doCheck = false;
+  };
+
+  rectpack = buildPythonPackage rec {
+    pname = "rectpack";
+    format = "pyproject";
+    version = "0.2.2";
+
+    buildInputs = [
+      setuptools
+    ];
+
+    propagatedBuildInputs =
+      [
+      ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-FeODUF/fuutV7GQKWCXZyizokBmmzdVS1uV+w2xouio=";
+    };
+    doCheck = false;
+  };
+
+  ruamel-yaml-string = buildPythonPackage rec {
+    pname = "ruamel.yaml.string";
+    format = "pyproject";
+    version = "0.1.1";
+
+    buildInputs = [
+      setuptools
+    ];
+
+    propagatedBuildInputs = [
+      ruamel-yaml
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-enrtzAVdRcAE04t1b1hHTr77EGhR9M5WzlhBVwl4Q1A=";
+    };
+    doCheck = false;
+  };
+
+  kfactory = buildPythonPackage rec {
+    pname = "kfactory";
+    format = "pyproject";
+    version = "0.18.4";
+
+    buildInputs = [
+      setuptools
+      setuptools_scm
+    ];
+
+    propagatedBuildInputs = [
+      aenum
+      cachetools
+      gitpython
+      loguru
+      klayout.pymod
+      pydantic
+      pydantic-settings
+      rectangle-packer
+      requests
+      ruamel-yaml-string
+      scipy
+      tomli
+      toolz
+      typer
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-2thvsHTlc61U5LiaDLlEAcKYY7Vh2ZGe5Z7tAN1sUtQ=";
+    };
+    doCheck = false;
+  };
+
+  trimesh-4_4_1 = buildPythonPackage rec {
+    pname = "trimesh";
+    format = "pyproject";
+    version = "4.4.1";
+
+    buildInputs = [
+      setuptools
+    ];
+
+    propagatedBuildInputs = [
+      numpy
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-dn/jyGa6dObZqdIWw07MHP4vvz8SmmwR1ZhxcFpZGro=";
+    };
+    doCheck = false;
+  };
+
+  self = buildPythonPackage rec {
+    pname = "gdsfactory";
+    format = "pyproject";
+    version = "8.7.3";
+
+    buildInputs = [
+      flit-core
+    ];
+
+    propagatedBuildInputs = [
+      matplotlib
+      numpy
+      orjson
+      pandas
+      pydantic
+      pydantic-settings
+      pydantic-extra-types
+      pyyaml
+      qrcode
+      rectpack
+      rich
+      scipy
+      shapely
+      toolz
+      types-pyyaml
+      typer
+      kfactory
+      watchdog
+      freetype-py
+      mapbox-earcut
+      networkx
+      #scikit-image
+      trimesh-4_4_1
+      ipykernel
+      attrs
+      jinja2
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-F2XMb1bSlg3Psydp1rag7Z4jO9+o23d0EySDY4WhqbI=";
+    };
+    doCheck = false;
+
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace "\"scikit-image\"," ""
+    '';
+  };
+in
+self

--- a/nix/klayout-gdsfactory.nix
+++ b/nix/klayout-gdsfactory.nix
@@ -14,14 +14,12 @@
 {
   klayout,
   gdsfactory,
-}:
-let
-
+}: let
   self = klayout.withPythonPackages (
-    ps: with ps; [
-      gdsfactory
-    ]
+    ps:
+      with ps; [
+        gdsfactory
+      ]
   );
-
 in
-self
+  self

--- a/nix/klayout-gdsfactory.nix
+++ b/nix/klayout-gdsfactory.nix
@@ -1,0 +1,27 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{
+  klayout,
+  gdsfactory,
+}:
+let
+
+  self = klayout.withPythonPackages (
+    ps: with ps; [
+      gdsfactory
+    ]
+  );
+
+in
+self

--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -158,7 +158,7 @@
 
     passthru = {
       inherit python3;
-      
+
       pymod = pythonModule;
 
       withPythonPackages = buildPythonEnvForInterpreter {

--- a/nix/yosys-ghdl.nix
+++ b/nix/yosys-ghdl.nix
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
 # Code adapated from Nixpkgs, original license follows:
 # ---
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -127,7 +127,7 @@
       });
       inherit withPlugins;
     };
-    
+
     makeFlags = [
       "PRETTY=0"
       "PREFIX=${placeholder "out"}"


### PR DESCRIPTION
Add a new package `klayout-gdsfactory` that ships KLayout with gdsfactory. This is necessary because the PCells in [sky130_klayout_pdk](https://github.com/efabless/sky130_klayout_pdk) require gdsfactory to function.

The files were formatted with nixfmt.