### PR TITLE
Composable Overlays

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,13 +22,16 @@ We compile and cache the tools for the following platforms:
 * [Netgen](http://opencircuitdesign.com/netgen)
 * [ngspice](https://ngspice.sourceforge.io)
 * [KLayout](https://klayout.de)
-    * (+ `.pythonModule` for Python module)
+    * (+ `.pymod` for Python module)
+* [GDSFactory]
+    * (+ `klayout-gdsfactory` as a shorthand for an environment with both installed)
 * [Surelog](https://github.com/chipsalliance/Surelog)
 * [Verilator](https://verilator.org)
 * [Xschem](https://xschem.sourceforge.io/stefan/index.html)
 * [Yosys](https://github.com/YosysHQ/yosys)
-    * (+ `.pythonModule` for "pyosys" Python module)
+    * (+ `.pyosys` for Python module)
     * (+ some plugins that can be accessed programmatically)
+    * (`yosysFull` for all plugins)
 
 ## Usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
   in {
     # Helper functions
     createDockerImage = import ./nix/create-docker.nix;
-    buildPythonEnvForInterpreter = import ./nix/build-python-env-for-interpreter.nix;
+    buildPythonEnvForInterpreter = import ;
     composePythonOverlay = composable: pkgs': pkgs: {
       python3 = pkgs.python3.override {
         packageOverrides = pkgs'.pythonOverrides;
@@ -65,6 +65,11 @@
     overlays = {
       default = lib.composeManyExtensions [
         (
+          pkgs': pkgs: {
+            buildPythonEnvForInterpreter = (import ./nix/build-python-env-for-interpreter.nix) lib;
+          }
+        )
+        (
           self.composePythonOverlay (pkgs': pkgs: pypkgs': pypkgs: let
             callPythonPackage = lib.callPackageWith (pkgs' // pkgs'.python3.pkgs);
           in {
@@ -95,9 +100,7 @@
           magic-vlsi = pkgs'.magic; # alias, there's a python package called magic
           netgen = callPackage ./nix/netgen.nix {};
           ngspice = callPackage ./nix/ngspice.nix {};
-          klayout = callPackage ./nix/klayout.nix {
-            inherit (self) buildPythonEnvForInterpreter;
-          };
+          klayout = callPackage ./nix/klayout.nix {};
           #
           klayout-gdsfactory = callPackage ./nix/klayout-gdsfactory.nix {
             inherit (pkgs'.python3.pkgs) gdsfactory;

--- a/flake.nix
+++ b/flake.nix
@@ -29,129 +29,109 @@
     nixpkgs,
     ...
   }: {
-    # Common
-    input-overlays = [
-      (
-        new: old: {
-          ## GHDL LLVM on Mac
-          ghdl-llvm = old.ghdl-llvm.overrideAttrs (self: super: {
-            meta.platforms = super.meta.platforms ++ ["x86_64-darwin"];
-          });
-
-          ## Cairo X11 on Mac
-          cairo = old.cairo.override {
-            x11Support = true;
-          };
-
-          ## slightly worse floating point errors cause ONE of the tests to fail
-          ## on x86_64-darwin
-          qrupdate = old.qrupdate.overrideAttrs (self: super: {
-            doCheck = old.system != "x86_64-darwin";
-          });
-        }
-      )
-    ];
-
     # Helper functions
     createDockerImage = import ./nix/create-docker.nix;
     buildPythonEnvForInterpreter = import ./nix/build-python-env-for-interpreter.nix;
-
-    forAllSystems = {
-      current ? null,
-      withInputs ? [],
-      overlays ? [],
-    }: function:
+    forAllSystems = fn:
       nixpkgs.lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
-      ] (
-        system: let
-          lib = nixpkgs.lib;
-          inputOverlays = (
-            lib.foldl
-            (
-              acc: elem: let
-                packages = elem.packages."${system}";
-                pythonPackages = lib.filterAttrs (name: value: builtins.hasAttr "pythonModule" value) elem.packages."${system}";
-              in
-                acc
-                ++ lib.lists.optionals (builtins.hasAttr "input-overlays" elem) elem.input-overlays
-                ++ [
-                  (new: old: {
-                    pythonPackagesExtensions =
-                      old.pythonPackagesExtensions
-                      ++ [
-                        (pnew: pold: pythonPackages)
-                      ];
-                  })
-                  (new: old: packages)
-                ]
+      ]
+      fn;
+
+    # Common
+    overlays = [
+      (
+        pkgs': pkgs: {
+          ## GHDL LLVM on Mac
+          ghdl-llvm = pkgs.ghdl-llvm.overrideAttrs (self: super: {
+            meta.platforms = super.meta.platforms ++ ["x86_64-darwin"];
+          });
+
+          ## Cairo X11 on Mac
+          cairo = pkgs.cairo.override {
+            x11Support = true;
+          };
+
+          ## slightly worse floating point errors cause ONE of the tests to fail
+          ## on x86_64-darwin
+          qrupdate = pkgs.qrupdate.overrideAttrs (self: super: {
+            doCheck = pkgs.system != "x86_64-darwin";
+          });
+        }
+      )
+      (
+        pkgs': pkgs: let
+          lib = pkgs.lib;
+          callPackage = lib.callPackageWith pkgs';
+        in {
+          # Python Packages
+          python3 = pkgs.python3.override {
+            packageOverrides = pkgs'.pythonOverrides;
+          };
+
+          pythonOverrides =
+            lib.composeExtensions (
+              let
+                callPythonPackage = lib.callPackageWith (pkgs' // pkgs'.python3.pkgs);
+              in pypkgs': pypkgs: {
+                gdsfactory = callPythonPackage ./nix/gdsfactory.nix {};
+              }
             )
-            []
-            withInputs
-          );
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays =
-              overlays
-              ++ inputOverlays
-              ++ (
-                if current == null
-                then []
-                else (lib.lists.optionals (builtins.hasAttr "input-overlays" current) current.input-overlays)
-              );
+            (if (builtins.hasAttr "pythonOverrides" pkgs) then pkgs.pythonOverrides else a: b: {});
+
+          # Other
+          magic = callPackage ./nix/magic.nix {};
+          magic-vlsi = pkgs'.magic; # alias, there's a python package called magic
+          netgen = callPackage ./nix/netgen.nix {};
+          ngspice = callPackage ./nix/ngspice.nix {};
+          klayout = callPackage ./nix/klayout.nix {
+            inherit (self) buildPythonEnvForInterpreter;
           };
-          packages-for-arch = function {
-            pkgs = pkgs;
-            callPackage = pkgs.lib.callPackageWith (pkgs // packages-for-arch);
-            callPythonPackage = pkgs.lib.callPackageWith (pkgs // pkgs.python3.pkgs // packages-for-arch);
-          };
-        in
-          packages-for-arch
-      );
+          #
+          klayout-gdsfactory = callPackage ./nix/klayout-gdsfactory.nix {};
+          surelog = callPackage ./nix/surelog.nix {};
+          tclFull = callPackage ./nix/tclFull.nix {};
+          tk-x11 = callPackage ./nix/tk-x11.nix {};
+          verilator = callPackage ./nix/verilator.nix {};
+          xschem = callPackage ./nix/xschem.nix {};
+          bitwuzla = callPackage ./nix/bitwuzla.nix {};
+          yosys = callPackage ./nix/yosys.nix {};
+          yosys-sby = callPackage ./nix/yosys-sby.nix {};
+          yosys-eqy = callPackage ./nix/yosys-eqy.nix {};
+          yosys-f4pga-sdc = callPackage ./nix/yosys-f4pga-sdc.nix {};
+          yosys-lighter = callPackage ./nix/yosys-lighter.nix {};
+          yosys-synlig-sv = callPackage ./nix/yosys-synlig-sv.nix {};
+          yosys-ghdl = callPackage ./nix/yosys-ghdl.nix {};
+          yosysFull = pkgs'.yosys.withPlugins (with pkgs';
+            [
+              yosys-sby
+              yosys-eqy
+              yosys-f4pga-sdc
+              yosys-lighter
+              yosys-synlig-sv
+            ]
+            ++ nixpkgs.lib.optionals pkgs.stdenv.isx86_64 [yosys-ghdl]);
+        }
+      )
+    ];
+
+    legacyPackages = self.forAllSystems (
+      system:
+        import nixpkgs {
+          inherit system;
+          inherit (self) overlays;
+        }
+    );
 
     # Outputs
-    packages =
-      self.forAllSystems {
-        current = self;
-        withInputs = [];
-      } (util:
-        with util; let
-          all =
-            {
-              magic = callPackage ./nix/magic.nix {};
-              magic-vlsi = all.magic; # alias, there's a python package called magic
-              netgen = callPackage ./nix/netgen.nix {};
-              ngspice = callPackage ./nix/ngspice.nix {};
-              klayout = callPackage ./nix/klayout.nix {
-                inherit (self) buildPythonEnvForInterpreter;
-              };
-              gdsfactory = callPythonPackage ./nix/gdsfactory.nix {};
-              klayout-gdsfactory = callPackage ./nix/klayout-gdsfactory.nix {};
-              surelog = callPackage ./nix/surelog.nix {};
-              tclFull = callPackage ./nix/tclFull.nix {};
-              tk-x11 = callPackage ./nix/tk-x11.nix {};
-              verilator = callPackage ./nix/verilator.nix {};
-              xschem = callPackage ./nix/xschem.nix {};
-              bitwuzla = callPackage ./nix/bitwuzla.nix {};
-              yosys = callPackage ./nix/yosys.nix {};
-              yosys-sby = callPackage ./nix/yosys-sby.nix {};
-              yosys-eqy = callPackage ./nix/yosys-eqy.nix {};
-              yosys-f4pga-sdc = callPackage ./nix/yosys-f4pga-sdc.nix {};
-              yosys-lighter = callPackage ./nix/yosys-lighter.nix {};
-              yosys-synlig-sv = callPackage ./nix/yosys-synlig-sv.nix {};
-              yosys-ghdl = callPackage ./nix/yosys-ghdl.nix {};
-              yosysFull = (all.yosys.withPlugins(with all; [
-                yosys-sby
-                yosys-eqy
-                yosys-f4pga-sdc
-                yosys-lighter
-                yosys-synlig-sv
-              ] ++ nixpkgs.lib.optionals pkgs.stdenv.isx86_64 [yosys-ghdl]));
-            };
-        in
-          all);
+    packages = self.forAllSystems (
+      system: {
+        inherit (self.legacyPackages."${system}") magic magic-vlsi netgen klayout klayout-gdsfactory surelog tclfull tk-x11 verilator xschem bitwuzla yosys yosys-sby yosys-eqy yosys-f4pga-sdc yosys-lighter yosys-synlig-sv yosys-ghdl yosysFull;
+        inherit (self.legacyPackages."${system}".python3.pkgs) gdsfactory;
+      }
+    );
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
   in {
     # Helper functions
     createDockerImage = import ./nix/create-docker.nix;
-    buildPythonEnvForInterpreter = import ;
     composePythonOverlay = composable: pkgs': pkgs: {
       python3 = pkgs.python3.override {
         packageOverrides = pkgs'.pythonOverrides;

--- a/nix/build-python-env-for-interpreter.nix
+++ b/nix/build-python-env-for-interpreter.nix
@@ -32,7 +32,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-{
+lib: lib.makeOverridable ({
   target,
   lib,
   buildEnv,
@@ -113,4 +113,4 @@ in
           };
       };
   in
-    env
+    env)

--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -49,9 +49,11 @@
   fetchurl,
   buildEnv,
   makeBinaryWrapper,
-  buildPythonEnvForInterpreter,
   version ? "0.29.4",
   sha256 ? "sha256-n0UXDUFPxiAy+cZh+sDQTsUzKClYDsYB6SKLeAxWX2Q=",
+  # Python environments
+  klayout,
+  buildPythonEnvForInterpreter,
 }: let
   pythonModule = python3.pkgs.toPythonModule (clangStdenv.mkDerivation {
     name = "${python3.name}-klayout";
@@ -162,7 +164,7 @@
       pymod = pythonModule;
 
       withPythonPackages = buildPythonEnvForInterpreter {
-        target = self;
+        target = klayout;
         inherit lib;
         inherit buildEnv;
         inherit makeBinaryWrapper;

--- a/nix/yosys-eqy.nix
+++ b/nix/yosys-eqy.nix
@@ -49,7 +49,7 @@ in
     makeFlags = [
       "YOSYS_CONFIG=${yosys}/bin/yosys-config"
     ];
-    
+
     nativeBuildInputs = [
       makeBinaryWrapper
     ];
@@ -84,7 +84,7 @@ in
       make -C tests/python "EQY=${py3env}/bin/python3 $PWD/src/eqy.py"
       runHook postCheck
     '';
-    
+
     fixupPhase = ''
       runHook preFixup
       mv $out/bin/eqy $out/bin/.eqy-wrapped

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -106,10 +106,11 @@
       boost185
     ];
     buildInputs = [
-      (python3.withPackages(ps: with ps; [
-        setuptools
-        wheel
-      ]))
+      (python3.withPackages (ps:
+        with ps; [
+          setuptools
+          wheel
+        ]))
       abc
     ];
 

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -55,6 +55,11 @@
   version ? "0.46",
   sha256 ? "sha256-ofMHVxqNd9WRJJnPiqgy7t8LorHozuOPqOf8NLl0e4U=",
   abc-sha256 ? "sha256-4KTrbk7JIJ97gfetKOoL4TYanPT09jk1b+78H0RQ234=",
+  # For environments
+  yosys,
+  buildEnv,
+  buildPythonEnvForInterpreter,
+  makeBinaryWrapper,
 }: let
   abc = clangStdenv.mkDerivation {
     name = "yosys-abc";
@@ -81,7 +86,8 @@
     python = python3;
     enablePython = true;
   };
-  self = clangStdenv.mkDerivation {
+in
+  clangStdenv.mkDerivation {
     name = "yosys";
     inherit version;
 
@@ -115,13 +121,14 @@
     ];
 
     passthru = {
+      inherit python3;
       pyosys = python3.pkgs.toPythonModule (clangStdenv.mkDerivation {
         name = "${python3.name}-pyosys";
-        buildInputs = [self];
+        buildInputs = [yosys];
         unpackPhase = "true";
         installPhase = ''
           mkdir -p $out/${python3.sitePackages}
-          ln -s ${self}/${python3.sitePackages}/pyosys $out/${python3.sitePackages}/pyosys
+          ln -s ${yosys}/${python3.sitePackages}/pyosys $out/${python3.sitePackages}/pyosys
           mkdir -p $out/${python3.sitePackages}/pyosys-${version}.dist-info
           sed 's/%VERSION%/${version}/' ${./supporting/yosys/PKG-INFO} > $out/${python3.sitePackages}/pyosys-${version}.dist-info/PKG-INFO
           echo "pyosys" > $out/${python3.sitePackages}/pyosys-${version}.dist-info/top_level.txt
@@ -133,7 +140,36 @@
           platforms = platforms.all;
         };
       });
-      inherit withPlugins;
+      withPlugins = plugins: let
+        paths = lib.closePropagation plugins;
+        dylibs = lib.lists.flatten (map (n: n.dylibs) plugins);
+      in let
+        module_flags = with builtins;
+          concatStringsSep " "
+          (map (so: "--add-flags -m --add-flags ${so}") dylibs);
+      in (symlinkJoin {
+        name = "${yosys.name}-with-plugins";
+        paths = paths ++ [yosys];
+        nativeBuildInputs = [makeWrapper];
+        postBuild = ''
+          cat <<SCRIPT > $out/bin/with_yosys_plugin_env
+          #!${bash}/bin/bash
+          export NIX_YOSYS_PLUGIN_DIRS='$out/share/yosys/plugins'
+          exec "\$@"
+          SCRIPT
+          chmod +x $out/bin/with_yosys_plugin_env
+          wrapProgram $out/bin/yosys \
+            --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
+            ${module_flags}
+        '';
+        inherit (yosys) passthru;
+      });
+      withPythonPackages = buildPythonEnvForInterpreter {
+        target = yosys;
+        inherit lib;
+        inherit buildEnv;
+        inherit makeBinaryWrapper;
+      };
     };
 
     makeFlags = [
@@ -172,29 +208,4 @@
       homepage = "https://www.yosyshq.com/";
       platforms = platforms.all;
     };
-  };
-  withPlugins = plugins: let
-    paths = lib.closePropagation plugins;
-    dylibs = lib.lists.flatten (map (n: n.dylibs) plugins);
-  in let
-    module_flags = with builtins;
-      concatStringsSep " "
-      (map (so: "--add-flags -m --add-flags ${so}") dylibs);
-  in (symlinkJoin {
-    name = "${self.name}-with-plugins";
-    paths = paths ++ [self];
-    nativeBuildInputs = [makeWrapper];
-    postBuild = ''
-      cat <<SCRIPT > $out/bin/with_yosys_plugin_env
-      #!${bash}/bin/bash
-      export NIX_YOSYS_PLUGIN_DIRS='$out/share/yosys/plugins'
-      exec "\$@"
-      SCRIPT
-      chmod +x $out/bin/with_yosys_plugin_env
-      wrapProgram $out/bin/yosys \
-        --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
-        ${module_flags}
-    '';
-  });
-in
-  self
+  }


### PR DESCRIPTION
nix-eda-based flakes now preferably provide their packages as an overlay. Contrary to before, this means there will be only one instance of nixpkgs in memory (vs. one for each nix-eda flake).

This also makes overrides more predictable.