### PR TITLE
feat: ci + bump tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
       - uses: cachix/cachix-action@v14
         with:
           name: openlane
-          authToken: ${{ env.CACHIX_TOKEN }}
+          authToken: ${{ secrets.CACHIX_TOKEN }}
       - run: |
           python3 ./.github/workflows/get_all_packages.py | xargs nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,12 @@ jobs:
       matrix:
         os: [
             {
-              name: "Ubuntu 22.04",
+              name: "Ubuntu 24.04",
               family: "linux",
-              runner: "ubuntu-22.04",
+              runner: "ubuntu-24.04",
               archs: "x86_64",
             },
-            ## Aarch64 is disabled for now: GitHub is committing to EOY
-            ## for free aarch64 runners for open-source projects and
-            ## emulation times out:
-            ## https://github.com/orgs/community/discussions/19197#discussioncomment-10550689
+            ## https://github.com/github/roadmap/issues/970
             # {
             #   name: "Ubuntu 22.04",
             #   family: "linux",
@@ -37,15 +34,6 @@ jobs:
               runner: "macos-14",
               archs: "arm64",
             },
-            ## Windows is disabled because of an issue with compiling FFI as
-            ## under MinGW in the GitHub Actions environment (SHELL variable has
-            ## whitespace.)
-            # {
-            #   name: "Windows Server 2019",
-            #   family: "windows",
-            #   runner: "windows-2019",
-            #   archs: "AMD64",
-            # },
           ]
     name: Nix Builds | ${{ matrix.os.name }} | ${{ matrix.os.archs }}
     runs-on: ${{ matrix.os.runner }}
@@ -56,6 +44,5 @@ jobs:
         with:
           name: openlane
           authToken: ${{ env.CACHIX_TOKEN }}
-      - run: nix build .#ngspice
-
-      # Add steps for your workflow here, such as building and testing your code
+      - run: |
+          python3 ./.github/workflows/get_all_packages.py | xargs nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: Build with Nix
+
+on:
+  push:
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+            {
+              name: "Ubuntu 22.04",
+              family: "linux",
+              runner: "ubuntu-22.04",
+              archs: "x86_64",
+            },
+            ## Aarch64 is disabled for now: GitHub is committing to EOY
+            ## for free aarch64 runners for open-source projects and
+            ## emulation times out:
+            ## https://github.com/orgs/community/discussions/19197#discussioncomment-10550689
+            # {
+            #   name: "Ubuntu 22.04",
+            #   family: "linux",
+            #   runner: "ubuntu-22.04",
+            #   archs: "aarch64",
+            # },
+            {
+              name: "macOS 13",
+              family: "macos",
+              runner: "macos-13",
+              archs: "x86_64",
+            },
+            {
+              name: "macOS 14",
+              family: "macos",
+              runner: "macos-14",
+              archs: "arm64",
+            },
+            ## Windows is disabled because of an issue with compiling FFI as
+            ## under MinGW in the GitHub Actions environment (SHELL variable has
+            ## whitespace.)
+            # {
+            #   name: "Windows Server 2019",
+            #   family: "windows",
+            #   runner: "windows-2019",
+            #   archs: "AMD64",
+            # },
+          ]
+    name: Nix Builds | ${{ matrix.os.name }} | ${{ matrix.os.archs }}
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/cachix-action@v14
+        with:
+          name: openlane
+          authToken: ${{ env.CACHIX_TOKEN }}
+      - run: nix build .#ngspice
+
+      # Add steps for your workflow here, such as building and testing your code

--- a/.github/workflows/get_all_packages.py
+++ b/.github/workflows/get_all_packages.py
@@ -1,0 +1,21 @@
+import sys
+import json
+import subprocess
+
+flake_meta_process = subprocess.Popen(
+    ["nix", "flake", "show", "--json"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    encoding="utf8",
+)
+flake_meta_process.wait()
+if flake_meta_process.returncode:
+    print(f"Failed to get flake metadata:", file=sys.stderr)
+    print(flake_meta_process.stderr.read(), file=sys.stderr)
+    exit(-1)
+flake_meta = json.load(flake_meta_process.stdout)
+packages = flake_meta["packages"]
+for platform, packages in packages.items():
+    for package, package_info in packages.items():
+        if len(package_info):
+            print(f".#packages.{platform}.{package}", end=" ")

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,8 @@ We compile and cache the tools for the following platforms:
 * [Surelog](https://github.com/chipsalliance/Surelog)
 * [Verilator](https://verilator.org)
 * [Xschem](https://xschem.sourceforge.io/stefan/index.html)
+* [Xyce](https://github.com/xyce/xyce)
+    * Linux only.
 * [Yosys](https://github.com/YosysHQ/yosys)
     * (+ `.pyosys` for Python module)
     * (+ some plugins that can be accessed programmatically)

--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
     packages = self.forAllSystems (
       system:
         {
-          inherit (self.legacyPackages."${system}") magic magic-vlsi netgen klayout klayout-gdsfactory surelog tclfull tk-x11 verilator xschem ngspice bitwuzla yosys yosys-sby yosys-eqy yosys-f4pga-sdc yosys-lighter yosys-synlig-sv yosysFull;
+          inherit (self.legacyPackages."${system}") magic magic-vlsi netgen klayout klayout-gdsfactory surelog tclFull tk-x11 verilator xschem ngspice bitwuzla yosys yosys-sby yosys-eqy yosys-f4pga-sdc yosys-lighter yosys-synlig-sv yosysFull;
           inherit (self.legacyPackages."${system}".python3.pkgs) gdsfactory gdstk tclint;
         }
         // lib.optionalAttrs self.legacyPackages."${system}".stdenv.hostPlatform.isLinux {

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,11 @@
     # Helper functions
     createDockerImage = import ./nix/create-docker.nix;
     composePythonOverlay = composable: pkgs': pkgs: {
-      pythonPackagesExtensions = pkgs.pythonPackagesExtensions ++ [
-        (composable pkgs' pkgs)
-      ];
+      pythonPackagesExtensions =
+        pkgs.pythonPackagesExtensions
+        ++ [
+          (composable pkgs' pkgs)
+        ];
     };
     flakesToOverlay = flakes: (
       lib.composeManyExtensions (builtins.map
@@ -107,6 +109,7 @@
           tk-x11 = callPackage ./nix/tk-x11.nix {};
           verilator = callPackage ./nix/verilator.nix {};
           xschem = callPackage ./nix/xschem.nix {};
+          xyce = callPackage ./nix/xyce.nix {};
           yosys = callPackage ./nix/yosys.nix {};
           yosys-sby = callPackage ./nix/yosys-sby.nix {};
           yosys-eqy = callPackage ./nix/yosys-eqy.nix {};
@@ -137,10 +140,17 @@
 
     # Outputs
     packages = self.forAllSystems (
-      system: {
-        inherit (self.legacyPackages."${system}") magic magic-vlsi netgen klayout klayout-gdsfactory surelog tclfull tk-x11 verilator xschem ngspice bitwuzla yosys yosys-sby yosys-eqy yosys-f4pga-sdc yosys-lighter yosys-synlig-sv yosys-ghdl yosysFull;
-        inherit (self.legacyPackages."${system}".python3.pkgs) gdsfactory gdstk tclint;
-      }
+      system:
+        {
+          inherit (self.legacyPackages."${system}") magic magic-vlsi netgen klayout klayout-gdsfactory surelog tclfull tk-x11 verilator xschem ngspice bitwuzla yosys yosys-sby yosys-eqy yosys-f4pga-sdc yosys-lighter yosys-synlig-sv yosysFull;
+          inherit (self.legacyPackages."${system}".python3.pkgs) gdsfactory gdstk tclint;
+        }
+        // lib.optionalAttrs self.legacyPackages."${system}".stdenv.hostPlatform.isLinux {
+          inherit (self.legacyPackages."${system}") xyce;
+        }
+        // lib.optionalAttrs self.legacyPackages."${system}".stdenv.hostPlatform.isx86_64 {
+          inherit (self.legacyPackages."${system}") yosys-ghdl;
+        }
     );
   };
 }

--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -49,8 +49,8 @@
   fetchurl,
   buildEnv,
   makeBinaryWrapper,
-  version ? "0.29.9",
-  sha256 ? "sha256-iCzq4+uZLBE3rJ/iAOzRfloXaZQv5WYEw66esogNTGM=",
+  version ? "0.29.10",
+  sha256 ? "sha256-fVrqFqPjtJKOebwpFUoPcK/KEEvchb6Zqj9vmlK4Uag=",
   # Python environments
   klayout,
   buildPythonEnvForInterpreter,

--- a/nix/magic.nix
+++ b/nix/magic.nix
@@ -45,9 +45,9 @@
   cairo,
   python3,
   gnused,
-  version ? "8.3.503",
+  version ? "8.3.515",
   rev ? null,
-  sha256 ? "sha256-jM7CdDdYu0cJZEhC42p4b250EQTq7XQbkZaIDFnIvXU=",
+  sha256 ? "sha256-YOSqzxZTXxSsibEMXXuhBYFgey1EXLWSZzBI8WPCXxE=",
 }:
 clangStdenv.mkDerivation {
   pname = "magic-vlsi";

--- a/nix/netgen.nix
+++ b/nix/netgen.nix
@@ -19,9 +19,9 @@
   tk,
   m4,
   python3,
-  version ? "1.5.287",
+  version ? "1.5.291",
   rev ? null,
-  sha256 ? "sha256-Zp44BVVAq8Ok/ZMI8F8C5uKASV103STuyOpXdiN5tlw=",
+  sha256 ? "sha256-31pdZD0h8kZQggVBVKIgJsT1HcR2CnAhnsWjL2p2SVY=",
 }:
 clangStdenv.mkDerivation {
   pname = "netgen";

--- a/nix/ngspice.nix
+++ b/nix/ngspice.nix
@@ -46,8 +46,8 @@
   libtool,
   readline,
   llvmPackages,
-  version ? "43",
-  sha256 ? "sha256-FN1qbwhTHyBRwTrmN5CkVwi9Q/PneIamqEiYwpexNpk=",
+  version ? "44",
+  sha256 ? "sha256-OGXROrRPHwH2jHrA4HFphORdzlqG0SZgPCbY3zAWHps=",
 }:
 clangStdenv.mkDerivation {
   pname = "ngspice";

--- a/nix/tclint.nix
+++ b/nix/tclint.nix
@@ -36,7 +36,7 @@
       rev = "v${self.version}";
       inherit sha256;
     };
-    
+
     patchPhase = ''
       runHook prePatch
       sed -Ei 's/schema==[0-9.]+/schema==${schema.version}/' pyproject.toml
@@ -44,12 +44,12 @@
       sed -Ei 's/importlib-metadata==[0-9.]+/importlib-metadata==${importlib-metadata.version}/' pyproject.toml
       runHook postPatch
     '';
-    
+
     nativeBuildInputs = [
       setuptools
       setuptools_scm
     ];
-    
+
     propagatedBuildInputs = [
       ply
       schema

--- a/nix/xschem.nix
+++ b/nix/xschem.nix
@@ -43,9 +43,9 @@
   pkg-config,
   tcl,
   tk-x11,
-  version ? "3.4.5-147-gce99d093", # Run 'git describe' on the xschem repo
-  rev ? "ce99d093c49d097a1c124b2d111ffe49db63116b",
-  sha256 ? "sha256-P0a44/osRZBAfwoLLDdTxbLdzERzO/sEt+pCUsyDfhc=",
+  version ? "3.4.6-106-g315c5bd6", # Run 'git describe' on the xschem repo
+  rev ? "315c5bd600945a596fda9a17a630d08009153476",
+  sha256 ? "sha256-H89aYuwl9qnya9H6Qo5Q2SkxgrKA0dkHeVghCwyoKiE=",
 }:
 stdenv.mkDerivation {
   pname = "xschem";

--- a/nix/xyce.nix
+++ b/nix/xyce.nix
@@ -1,0 +1,208 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchgit,
+  lib,
+  autoconf,
+  automake,
+  bison,
+  blas,
+  flex,
+  fftw,
+  gfortran,
+  lapack,
+  libtool_2,
+  mpi,
+  suitesparse,
+  trilinos,
+  withMPI ? false,
+  # for doc
+  texliveMedium,
+  enableDocs ? true,
+  # for tests
+  bash,
+  bc,
+  openssh, # required by MPI
+  perl,
+  python3,
+  enableTests ? true,
+  version ? "7.8.0",
+  sha256 ? "sha256-+aNy2bGuFQ517FZUvU0YqN0gmChRpVuFEmFGTCx9AgY=",
+  regression-sha256 ? "sha256-Fxi/NpXXIw/bseWaLi2iQ4sg4S9Z+othGgSvQoxyJ9c=",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xyce";
+  inherit version;
+
+  # Using fetchurl or fetchFromGitHub doesn't include the manuals
+  # due to .gitattributes files
+  xyce_src = fetchgit {
+    name = "xyce_src_${version}";
+    url = "https://github.com/Xyce/Xyce.git";
+    rev = "Release-${version}";
+    inherit sha256;
+  };
+
+  regression_src = fetchFromGitHub {
+    name = "xyce_regression_src_${version}";
+    owner = "Xyce";
+    repo = "Xyce_Regression";
+    rev = "Release-${version}";
+    sha256 = regression-sha256;
+  };
+
+  srcs = [finalAttrs.xyce_src finalAttrs.regression_src];
+
+  sourceRoot = finalAttrs.xyce_src.name;
+
+  preConfigure = "./bootstrap";
+
+  configureFlags =
+    [
+      "CXXFLAGS=-O3"
+      "--enable-xyce-shareable"
+      "--enable-shared"
+      "--enable-stokhos"
+      "--enable-amesos2"
+    ]
+    ++ lib.optionals trilinos.withMPI [
+      "--enable-mpi"
+      "CXX=mpicxx"
+      "CC=mpicc"
+      "F77=mpif77"
+    ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs =
+    [
+      autoconf
+      automake
+      gfortran
+      libtool_2
+    ]
+    ++ lib.optionals enableDocs [
+      (texliveMedium.withPackages (ps:
+        with ps; [
+          enumitem
+          koma-script
+          optional
+          framed
+          enumitem
+          multirow
+          newtx
+          preprint
+        ]))
+    ];
+
+  buildInputs =
+    [
+      bison
+      blas
+      flex
+      fftw
+      lapack
+      suitesparse
+      trilinos
+    ]
+    ++ lib.optionals trilinos.withMPI [mpi];
+
+  doCheck = enableTests;
+
+  postPatch = ''
+    pushd ../${finalAttrs.regression_src.name}
+    find Netlists -type f -regex ".*\.sh\|.*\.pl" -exec chmod ugo+x {} \;
+    # some tests generate new files, some overwrite netlists
+    find . -type d -exec chmod u+w {} \;
+    find . -type f -name "*.cir" -exec chmod u+w {} \;
+    patchShebangs Netlists/ TestScripts/
+    # patch script generating functions
+    sed -i -E 's|/usr/bin/env perl|${lib.escapeRegex perl.outPath}/bin/perl|'  \
+      TestScripts/XyceRegression/Testing/Netlists/RunOptions/runOptions.cir.sh
+    sed -i -E 's|/bin/sh|${lib.escapeRegex bash.outPath}/bin/sh|' \
+      TestScripts/XyceRegression/Testing/Netlists/RunOptions/runOptions.cir.sh
+    popd
+  '';
+
+  nativeCheckInputs =
+    [
+      bc
+      perl
+      (python3.withPackages (ps: with ps; [numpy scipy]))
+    ]
+    ++ lib.optionals trilinos.withMPI [mpi openssh];
+
+  checkPhase = ''
+    XYCE_BINARY="$(pwd)/src/Xyce"
+    EXECSTRING="${lib.optionalString trilinos.withMPI "mpirun -np 2 "}$XYCE_BINARY"
+    TEST_ROOT="$(pwd)/../${finalAttrs.regression_src.name}"
+
+    # Honor the TMP variable
+    sed -i -E 's|/tmp|\$TMP|' $TEST_ROOT/TestScripts/suggestXyceTagList.sh
+
+    EXLUDE_TESTS_FILE=$TMP/exclude_tests.$$
+    # Gold standard has additional ":R" suffix in result column label
+    echo "Output/HB/hb-step-tecplot.cir" >> $EXLUDE_TESTS_FILE
+    # This test makes Xyce access /sys/class/net when run with MPI
+    ${lib.optionalString withMPI "echo \"CommandLine/command_line.cir\" >> $EXLUDE_TESTS_FILE"}
+
+    $TEST_ROOT/TestScripts/run_xyce_regression \
+      --output="$(pwd)/Xyce_Test" \
+      --xyce_test="''${TEST_ROOT}" \
+      --taglist="$($TEST_ROOT/TestScripts/suggestXyceTagList.sh "$XYCE_BINARY" | sed -E -e 's/TAGLIST=([^ ]+).*/\1/' -e '2,$d')" \
+      --resultfile="$(pwd)/test_results" \
+      --excludelist="$EXLUDE_TESTS_FILE" \
+      "''${EXECSTRING}"
+  '';
+
+  outputs = ["out" "doc"];
+
+  postInstall = lib.optionalString enableDocs ''
+    local docFiles=("doc/Users_Guide/Xyce_UG"
+      "doc/Reference_Guide/Xyce_RG"
+      "doc/Release_Notes/Release_Notes_${lib.versions.majorMinor version}/Release_Notes_${lib.versions.majorMinor version}")
+
+    # SANDIA LaTeX class and some organization logos are not publicly available see
+    # https://groups.google.com/g/xyce-users/c/MxeViRo8CT4/m/ppCY7ePLEAAJ
+    for img in "snllineblubrd" "snllineblk" "DOEbwlogo" "NNSA_logo"; do
+      sed -i -E "s/\\includegraphics\[height=(0.[1-9]in)\]\{$img\}/\\mbox\{\\rule\{0mm\}\{\1\}\}/" ''${docFiles[2]}.tex
+    done
+
+    install -d $doc/share/doc/${finalAttrs.pname}-${version}/
+    for d in ''${docFiles[@]}; do
+      # Use a public document class
+      sed -i -E 's/\\documentclass\[11pt,report\]\{SANDreport\}/\\documentclass\[11pt,letterpaper\]\{scrreprt\}/' $d.tex
+      sed -i -E 's/\\usepackage\[sand\]\{optional\}/\\usepackage\[report\]\{optional\}/' $d.tex
+      pushd $(dirname $d)
+      make
+      install -t $doc/share/doc/${finalAttrs.pname}-${version}/ $(basename $d.pdf)
+      popd
+    done
+  '';
+
+  meta = {
+    description = "High-performance analog circuit simulator";
+    longDescription = ''
+      Xyce is a SPICE-compatible, high-performance analog circuit simulator,
+      capable of solving extremely large circuit problems by supporting
+      large-scale parallel computing platforms.
+    '';
+    homepage = "https://xyce.sandia.gov";
+    license = lib.licenses.gpl3;
+    broken = stdenv.hostPlatform.isDarwin;
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Some routine updates to the tools:

- Update KLayout to `0.29.10`
- Update magic to `8.3.515`
  - Important for OL2 on IHP
- Update netgen to `1.5.291`
- Update ngspice to `44`
- Update xschem to `3.4.6-106`